### PR TITLE
Fix cran check error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,22 @@
 Package: pagemap
 Type: Package
 Title: Create Mini Map for Web Pages
-Version: 0.1.1
-Date: 2020-09-07
+Version: 0.1.2
+Date: 2021-08-12
 Authors@R: c(
-    person(given = "Wei", family = "Su", role = c("aut", "cre"), email = "swsoyee@gmail.com"),
-    person(given = "Lars", family = "Jung", role = c("aut", "cph"), comment = "pagemap library in htmlwidgets/lib, https://github.com/lrsjng/pagemap"))
+    person(
+        given = "Wei",
+        family = "Su",
+        role = c("aut", "cre"),
+        email = "swsoyee@gmail.com",
+        comment = c(ORCID = "0000-0002-9302-5332")
+    ),
+    person(
+        given = "Lars",
+        family = "Jung",
+        role = c("aut", "cph"),
+        comment = "pagemap library in htmlwidgets/lib, https://github.com/lrsjng/pagemap")
+    )
 Maintainer: Wei Su <swsoyee@gmail.com>
 Description: Quickly and easily add a mini map to your 'rmarkdown' html documents.
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Suggests:
     devtools
 License: MIT + file LICENSE
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr

--- a/vignettes/pagemap.Rmd
+++ b/vignettes/pagemap.Rmd
@@ -22,8 +22,11 @@ if (!knitr::is_html_output(excludes = "markdown")) {
   logo_path <- "./vignettes/pagemap.png"
   cat("# pagemapR")
 } else {
-  library(devtools)
-  install_github("swsoyee/pagemapR", quiet = TRUE)
+  install.packages(
+    "pagemap",
+    repos = "http://cran.us.r-project.org",
+    quiet = TRUE
+  )
   logo_path <- "./pagemap.png"
 }
 ```


### PR DESCRIPTION
## Problem

> Version: 0.1.1
> Check: re-building of vignette outputs
> Result: WARN
>     Error(s) in re-building vignettes:
>      ...
>     --- re-building 'pagemap.Rmd' using rmarkdown
>     Loading required package: usethis
>     Warning in i.p(...) :
>      'lib = "/home/hornik/tmp/R.check/r-devel-clang/Work/build/Packages"' is not writable
>     Quitting from lines 20-29 (pagemap.Rmd)
>     Error: processing vignette 'pagemap.Rmd' failed with diagnostics:
>     Failed to install 'pagemap' from GitHub:
>      unable to install packages
>     --- failed re-building 'pagemap.Rmd'
>     
>     SUMMARY: processing the following file failed:
>      'pagemap.Rmd'
>     
>     Error: Vignette re-building failed.
>     Execution halted